### PR TITLE
Rename AbstractSynatxTree → AbstractSyntaxTree

### DIFF
--- a/include/ast/abstractsyntaxtree.h
+++ b/include/ast/abstractsyntaxtree.h
@@ -38,13 +38,13 @@ private:
 	bool m_member;
 };
 
-class AbstractSynatxTree {
+class AbstractSyntaxTree {
 public:
-	AbstractSynatxTree(size_t rootModuleId = Module::main().moduleId);
-	~AbstractSynatxTree();
+	AbstractSyntaxTree(size_t rootModuleId = Module::main().moduleId);
+	~AbstractSyntaxTree();
 
 	typedef size_t CallHandler;
-	typedef std::function<void(AbstractSynatxTree *)> Builtin;
+	typedef std::function<void(AbstractSyntaxTree *)> Builtin;
 
 	Instruction &next();
 	void jmp(size_t pos);

--- a/include/memory/casttool.h
+++ b/include/memory/casttool.h
@@ -4,10 +4,10 @@
 #include "memory/builtin/array.h"
 #include "memory/builtin/hash.h"
 
-class AbstractSynatxTree;
+class AbstractSyntaxTree;
 
-double to_number(AbstractSynatxTree *ast, const Reference &ref);
-bool to_boolean(AbstractSynatxTree *ast, const Reference &ref);
+double to_number(AbstractSyntaxTree *ast, const Reference &ref);
+bool to_boolean(AbstractSyntaxTree *ast, const Reference &ref);
 std::string to_char(const Reference &ref);
 std::string to_string(const Reference &ref);
 Array::values_type to_array(const Reference &ref);

--- a/include/memory/memorytool.h
+++ b/include/memory/memorytool.h
@@ -8,47 +8,47 @@
 #include "system/printer.h"
 
 class SymbolTable;
-class AbstractSynatxTree;
+class AbstractSyntaxTree;
 
-size_t get_base(AbstractSynatxTree *ast);
+size_t get_base(AbstractSyntaxTree *ast);
 std::string type_name(const Reference &ref);
 
 Printer *to_printer(SharedReference ref);
 void print(Printer *printer, SharedReference ref);
 
-void init_call(AbstractSynatxTree *ast);
-void exit_call(AbstractSynatxTree *ast);
-void init_parameter(AbstractSynatxTree *ast, const std::string &symbol);
-Function::mapping_type::iterator find_function_signature(AbstractSynatxTree *ast, Function::mapping_type &mapping, int signature);
+void init_call(AbstractSyntaxTree *ast);
+void exit_call(AbstractSyntaxTree *ast);
+void init_parameter(AbstractSyntaxTree *ast, const std::string &symbol);
+Function::mapping_type::iterator find_function_signature(AbstractSyntaxTree *ast, Function::mapping_type &mapping, int signature);
 
-void yield(AbstractSynatxTree *ast);
-void load_default_result(AbstractSynatxTree *ast);
+void yield(AbstractSyntaxTree *ast);
+void load_default_result(AbstractSyntaxTree *ast);
 
 SharedReference get_symbol_reference(SymbolTable *symbols, const std::string &symbol);
-SharedReference get_object_member(AbstractSynatxTree *ast, const std::string &member);
-void reduce_member(AbstractSynatxTree *ast);
+SharedReference get_object_member(AbstractSyntaxTree *ast, const std::string &member);
+void reduce_member(AbstractSyntaxTree *ast);
 
-std::string var_symbol(AbstractSynatxTree *ast);
-void create_symbol(AbstractSynatxTree *ast, const std::string &symbol, Reference::Flags flags);
+std::string var_symbol(AbstractSyntaxTree *ast);
+void create_symbol(AbstractSyntaxTree *ast, const std::string &symbol, Reference::Flags flags);
 
-void array_append(AbstractSynatxTree *ast);
+void array_append(AbstractSyntaxTree *ast);
 void array_append(Array *array, const SharedReference &item);
 SharedReference array_get_item(Array *array, long index);
 size_t array_index(Array *array, long index);
 
-void hash_insert(AbstractSynatxTree *ast);
+void hash_insert(AbstractSyntaxTree *ast);
 void hash_insert(Hash *hash, const SharedReference &key, const SharedReference &value);
 SharedReference hash_get_item(Hash *hash, const SharedReference &key);
 SharedReference hash_get_key(const Hash::values_type::value_type &item);
 SharedReference hash_get_value(const Hash::values_type::value_type &item);
 
-void iterator_init(AbstractSynatxTree *ast, size_t length);
+void iterator_init(AbstractSyntaxTree *ast, size_t length);
 void iterator_init(Iterator *iterator, const Reference &ref);
 void iterator_insert(Iterator *iterator, const SharedReference &item);
 void iterator_add(Iterator *iterator, const SharedReference &item);
 bool iterator_next(Iterator *iterator, SharedReference &item);
 
-void regex_match(AbstractSynatxTree *ast);
-void regex_unmatch(AbstractSynatxTree *ast);
+void regex_match(AbstractSyntaxTree *ast);
+void regex_unmatch(AbstractSyntaxTree *ast);
 
 #endif // MEMORY_TOOL_H

--- a/include/memory/operatortool.h
+++ b/include/memory/operatortool.h
@@ -3,51 +3,51 @@
 
 #include "casttool.h"
 
-class AbstractSynatxTree;
+class AbstractSyntaxTree;
 
-void move_operator(AbstractSynatxTree *ast);
-void copy_operator(AbstractSynatxTree *ast);
-void call_operator(AbstractSynatxTree *ast, int signature);
-void call_member_operator(AbstractSynatxTree *ast, int signature);
-void add_operator(AbstractSynatxTree *ast);
-void sub_operator(AbstractSynatxTree *ast);
-void mul_operator(AbstractSynatxTree *ast);
-void div_operator(AbstractSynatxTree *ast);
-void pow_operator(AbstractSynatxTree *ast);
-void mod_operator(AbstractSynatxTree *ast);
-void is_operator(AbstractSynatxTree *ast);
-void eq_operator(AbstractSynatxTree *ast);
-void ne_operator(AbstractSynatxTree *ast);
-void lt_operator(AbstractSynatxTree *ast);
-void gt_operator(AbstractSynatxTree *ast);
-void le_operator(AbstractSynatxTree *ast);
-void ge_operator(AbstractSynatxTree *ast);
-void and_operator(AbstractSynatxTree *ast);
-void or_operator(AbstractSynatxTree *ast);
-void band_operator(AbstractSynatxTree *ast);
-void bor_operator(AbstractSynatxTree *ast);
-void xor_operator(AbstractSynatxTree *ast);
-void inc_operator(AbstractSynatxTree *ast);
-void dec_operator(AbstractSynatxTree *ast);
-void not_operator(AbstractSynatxTree *ast);
-void compl_operator(AbstractSynatxTree *ast);
-void pos_operator(AbstractSynatxTree *ast);
-void neg_operator(AbstractSynatxTree *ast);
-void shift_left_operator(AbstractSynatxTree *ast);
-void shift_right_operator(AbstractSynatxTree *ast);
-void inclusive_range_operator(AbstractSynatxTree *ast);
-void exclusive_range_operator(AbstractSynatxTree *ast);
-void typeof_operator(AbstractSynatxTree *ast);
-void membersof_operator(AbstractSynatxTree *ast);
-void subscript_operator(AbstractSynatxTree *ast);
+void move_operator(AbstractSyntaxTree *ast);
+void copy_operator(AbstractSyntaxTree *ast);
+void call_operator(AbstractSyntaxTree *ast, int signature);
+void call_member_operator(AbstractSyntaxTree *ast, int signature);
+void add_operator(AbstractSyntaxTree *ast);
+void sub_operator(AbstractSyntaxTree *ast);
+void mul_operator(AbstractSyntaxTree *ast);
+void div_operator(AbstractSyntaxTree *ast);
+void pow_operator(AbstractSyntaxTree *ast);
+void mod_operator(AbstractSyntaxTree *ast);
+void is_operator(AbstractSyntaxTree *ast);
+void eq_operator(AbstractSyntaxTree *ast);
+void ne_operator(AbstractSyntaxTree *ast);
+void lt_operator(AbstractSyntaxTree *ast);
+void gt_operator(AbstractSyntaxTree *ast);
+void le_operator(AbstractSyntaxTree *ast);
+void ge_operator(AbstractSyntaxTree *ast);
+void and_operator(AbstractSyntaxTree *ast);
+void or_operator(AbstractSyntaxTree *ast);
+void band_operator(AbstractSyntaxTree *ast);
+void bor_operator(AbstractSyntaxTree *ast);
+void xor_operator(AbstractSyntaxTree *ast);
+void inc_operator(AbstractSyntaxTree *ast);
+void dec_operator(AbstractSyntaxTree *ast);
+void not_operator(AbstractSyntaxTree *ast);
+void compl_operator(AbstractSyntaxTree *ast);
+void pos_operator(AbstractSyntaxTree *ast);
+void neg_operator(AbstractSyntaxTree *ast);
+void shift_left_operator(AbstractSyntaxTree *ast);
+void shift_right_operator(AbstractSyntaxTree *ast);
+void inclusive_range_operator(AbstractSyntaxTree *ast);
+void exclusive_range_operator(AbstractSyntaxTree *ast);
+void typeof_operator(AbstractSyntaxTree *ast);
+void membersof_operator(AbstractSyntaxTree *ast);
+void subscript_operator(AbstractSyntaxTree *ast);
 
-void find_defined_symbol(AbstractSynatxTree *ast, const std::string &symbol);
-void find_defined_member(AbstractSynatxTree *ast, const std::string &symbol);
-void check_defined(AbstractSynatxTree *ast);
+void find_defined_symbol(AbstractSyntaxTree *ast, const std::string &symbol);
+void find_defined_member(AbstractSyntaxTree *ast, const std::string &symbol);
+void check_defined(AbstractSyntaxTree *ast);
 
-void in_find(AbstractSynatxTree *ast);
-void in_init(AbstractSynatxTree *ast);
-void in_next(AbstractSynatxTree *ast);
-void in_check(AbstractSynatxTree *ast);
+void in_find(AbstractSyntaxTree *ast);
+void in_init(AbstractSyntaxTree *ast);
+void in_next(AbstractSyntaxTree *ast);
+void in_check(AbstractSyntaxTree *ast);
 
 #endif // OPERATOR_TOOL_H

--- a/include/scheduler/process.h
+++ b/include/scheduler/process.h
@@ -16,7 +16,7 @@ public:
 	bool isOver();
 
 private:
-	AbstractSynatxTree m_ast;
+	AbstractSyntaxTree m_ast;
 	bool m_endless;
 };
 

--- a/include/scheduler/processor.h
+++ b/include/scheduler/processor.h
@@ -1,8 +1,8 @@
 #ifndef PROCESSOR_H
 #define PROCESSOR_H
 
-class AbstractSynatxTree;
+class AbstractSyntaxTree;
 
-bool run_step(AbstractSynatxTree *ast);
+bool run_step(AbstractSyntaxTree *ast);
 
 #endif // PROCESSOR_H

--- a/include/system/plugin.h
+++ b/include/system/plugin.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-class AbstractSynatxTree;
+class AbstractSyntaxTree;
 
 class Plugin {
 public:
@@ -13,7 +13,7 @@ public:
 	static Plugin *load(const std::string &plugin);
 	static std::string functionName(const std::string &name, int signature);
 
-	bool call(const std::string &function, int signature, AbstractSynatxTree *ast);
+	bool call(const std::string &function, int signature, AbstractSyntaxTree *ast);
 
 	std::string getPath() const;
 
@@ -25,7 +25,7 @@ protected:
 #else
 	typedef void *handle_type;
 #endif
-	typedef void (*function_type)(AbstractSynatxTree *ast);
+	typedef void (*function_type)(AbstractSyntaxTree *ast);
 
 	function_type getFunction(const std::string &name);
 

--- a/src/ast/abstractsyntaxtree.cpp
+++ b/src/ast/abstractsyntaxtree.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-map<int, map<int, AbstractSynatxTree::Builtin>> AbstractSynatxTree::g_builtinMembers;
+map<int, map<int, AbstractSyntaxTree::Builtin>> AbstractSyntaxTree::g_builtinMembers;
 
 Call::Call(Reference *ref) : m_ref(ref), m_member(false) {}
 
@@ -22,15 +22,15 @@ bool Call::isMember() const {
 	return m_member;
 }
 
-AbstractSynatxTree::AbstractSynatxTree(size_t rootModuleId) : m_currentCtx(new Context) {
+AbstractSyntaxTree::AbstractSyntaxTree(size_t rootModuleId) : m_currentCtx(new Context) {
 
 	m_currentCtx->module = Module::get(rootModuleId);
 	m_currentCtx->iptr = 0;
 
-	m_callbackId = add_error_callback(bind(&AbstractSynatxTree::dumpCallStack, this));
+	m_callbackId = add_error_callback(bind(&AbstractSyntaxTree::dumpCallStack, this));
 }
 
-AbstractSynatxTree::~AbstractSynatxTree() {
+AbstractSyntaxTree::~AbstractSyntaxTree() {
 
 	remove_error_callback(m_callbackId);
 
@@ -41,15 +41,15 @@ AbstractSynatxTree::~AbstractSynatxTree() {
 	delete m_currentCtx;
 }
 
-Instruction &AbstractSynatxTree::next() {
+Instruction &AbstractSyntaxTree::next() {
 	return m_currentCtx->module->at(m_currentCtx->iptr++);
 }
 
-void AbstractSynatxTree::jmp(size_t pos) {
+void AbstractSyntaxTree::jmp(size_t pos) {
 	m_currentCtx->iptr = pos;
 }
 
-bool AbstractSynatxTree::call(int module, size_t pos) {
+bool AbstractSyntaxTree::call(int module, size_t pos) {
 
 	if (module < 0) {
 		g_builtinMembers[module][pos](this);
@@ -65,45 +65,45 @@ bool AbstractSynatxTree::call(int module, size_t pos) {
 	return true;
 }
 
-void AbstractSynatxTree::exitCall() {
+void AbstractSyntaxTree::exitCall() {
 	delete m_currentCtx;
 	m_currentCtx = m_callStack.top();
 	m_callStack.pop();
 }
 
-void AbstractSynatxTree::openPrinter(Printer *printer) {
+void AbstractSyntaxTree::openPrinter(Printer *printer) {
 	m_currentCtx->printers.push(printer);
 }
 
-void AbstractSynatxTree::closePrinter() {
+void AbstractSyntaxTree::closePrinter() {
 	delete m_currentCtx->printers.top();
 	m_currentCtx->printers.pop();
 }
 
-vector<SharedReference> &AbstractSynatxTree::stack() {
+vector<SharedReference> &AbstractSyntaxTree::stack() {
 	return m_stack;
 }
 
-stack<Call> &AbstractSynatxTree::waitingCalls() {
+stack<Call> &AbstractSyntaxTree::waitingCalls() {
 	return m_waitingCalls;
 }
 
-SymbolTable &AbstractSynatxTree::symbols() {
+SymbolTable &AbstractSyntaxTree::symbols() {
 	return m_currentCtx->symbols;
 }
 
-Printer *AbstractSynatxTree::printer() {
+Printer *AbstractSyntaxTree::printer() {
 	if (m_currentCtx->printers.empty()) {
 		return nullptr;
 	}
 	return m_currentCtx->printers.top();
 }
 
-void AbstractSynatxTree::loadModule(const std::string &module) {
+void AbstractSyntaxTree::loadModule(const std::string &module) {
 	call(Module::load(module).moduleId, 0);
 }
 
-bool AbstractSynatxTree::exitModule() {
+bool AbstractSyntaxTree::exitModule() {
 
 	bool over = m_callStack.empty();
 
@@ -114,7 +114,7 @@ bool AbstractSynatxTree::exitModule() {
 	return !over;
 }
 
-void AbstractSynatxTree::setRetrivePoint(size_t offset) {
+void AbstractSyntaxTree::setRetrivePoint(size_t offset) {
 
 	RetiveContext ctx;
 
@@ -126,11 +126,11 @@ void AbstractSynatxTree::setRetrivePoint(size_t offset) {
 	m_retrivePoints.push(ctx);
 }
 
-void AbstractSynatxTree::unsetRetivePoint() {
+void AbstractSyntaxTree::unsetRetivePoint() {
 	m_retrivePoints.pop();
 }
 
-void AbstractSynatxTree::raise(SharedReference exception) {
+void AbstractSyntaxTree::raise(SharedReference exception) {
 
 	if (m_retrivePoints.empty()) {
 		error("exception : %s", to_string(*exception).c_str());
@@ -158,15 +158,15 @@ void AbstractSynatxTree::raise(SharedReference exception) {
 	}
 }
 
-AbstractSynatxTree::CallHandler AbstractSynatxTree::getCallHandler() const {
+AbstractSyntaxTree::CallHandler AbstractSyntaxTree::getCallHandler() const {
 	return m_callStack.size();
 }
 
-bool AbstractSynatxTree::callInProgress(CallHandler handler) const {
+bool AbstractSyntaxTree::callInProgress(CallHandler handler) const {
 	return handler < m_callStack.size();
 }
 
-pair<int, int> AbstractSynatxTree::createBuiltinMethode(int type, Builtin methode) {
+pair<int, int> AbstractSyntaxTree::createBuiltinMethode(int type, Builtin methode) {
 
 	auto &methodes = g_builtinMembers[-type];
 	int offset = methodes.size();
@@ -176,7 +176,7 @@ pair<int, int> AbstractSynatxTree::createBuiltinMethode(int type, Builtin method
 	return pair<int, int>(-type, offset);
 }
 
-void AbstractSynatxTree::dumpCallStack() {
+void AbstractSyntaxTree::dumpCallStack() {
 
 	fprintf(stderr, "  Module '%s', line %lu\n", Module::name(m_currentCtx->module).c_str(), Module::debug(Module::id(m_currentCtx->module))->lineNumber(m_currentCtx->iptr));
 

--- a/src/lib/system/file.cpp
+++ b/src/lib/system/file.cpp
@@ -10,7 +10,7 @@ using namespace std;
 
 extern "C" {
 
-void mint_file_fopen_2(AbstractSynatxTree *ast) {
+void mint_file_fopen_2(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -31,7 +31,7 @@ void mint_file_fopen_2(AbstractSynatxTree *ast) {
 	}
 }
 
-void mint_file_fclose_1(AbstractSynatxTree *ast) {
+void mint_file_fclose_1(AbstractSyntaxTree *ast) {
 
 	Reference &file = *ast->stack().back();
 
@@ -40,7 +40,7 @@ void mint_file_fclose_1(AbstractSynatxTree *ast) {
 	}
 }
 
-void mint_file_readline_1(AbstractSynatxTree *ast) {
+void mint_file_readline_1(AbstractSyntaxTree *ast) {
 
 	Reference &file = *ast->stack().back();
 

--- a/src/memory/builtin/array.cpp
+++ b/src/memory/builtin/array.cpp
@@ -17,7 +17,7 @@ Array::Array() : Object(ArrayClass::instance()) {}
 
 ArrayClass::ArrayClass() : Class("array", Class::array) {
 
-	createBuiltinMember(":=", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember(":=", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -32,7 +32,7 @@ ArrayClass::ArrayClass() : Class("array", Class::array) {
 							ast->stack().pop_back();
 						}));
 
-	createBuiltinMember("+", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("+", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -53,7 +53,7 @@ ArrayClass::ArrayClass() : Class("array", Class::array) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember("[]", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("[]", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -69,7 +69,7 @@ ArrayClass::ArrayClass() : Class("array", Class::array) {
 
 	/// \todo register operator overloads
 
-	createBuiltinMember("size", 1, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("size", 1, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							Reference &value = *ast->stack().back();
 
@@ -80,7 +80,7 @@ ArrayClass::ArrayClass() : Class("array", Class::array) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember("erase", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("erase", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 

--- a/src/memory/builtin/hash.cpp
+++ b/src/memory/builtin/hash.cpp
@@ -14,7 +14,7 @@ Hash::Hash() : Object(HashClass::instance()) {}
 
 HashClass::HashClass() : Class("hash", Class::hash) {
 
-	createBuiltinMember(":=", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember(":=", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -29,7 +29,7 @@ HashClass::HashClass() : Class("hash", Class::hash) {
 							ast->stack().pop_back();
 						}));
 
-	createBuiltinMember("+", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("+", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -50,7 +50,7 @@ HashClass::HashClass() : Class("hash", Class::hash) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember("[]", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("[]", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -66,7 +66,7 @@ HashClass::HashClass() : Class("hash", Class::hash) {
 
 	/// \todo register operator overloads
 
-	createBuiltinMember("size", 1, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("size", 1, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							Reference &value = *ast->stack().back();
 
@@ -77,7 +77,7 @@ HashClass::HashClass() : Class("hash", Class::hash) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember("erase", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("erase", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 

--- a/src/memory/builtin/iterator.cpp
+++ b/src/memory/builtin/iterator.cpp
@@ -14,7 +14,7 @@ Iterator::Iterator() : Object(IteratorClass::instance()) {}
 
 IteratorClass::IteratorClass() : Class("iterator", Class::iterator) {
 
-	createBuiltinMember(":=", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember(":=", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -39,7 +39,7 @@ IteratorClass::IteratorClass() : Class("iterator", Class::iterator) {
 							ast->stack().pop_back();
 						}));
 
-	createBuiltinMember("next", 1, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("next", 1, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							Reference &self = *ast->stack().back();
 							SharedReference result;

--- a/src/memory/builtin/library.cpp
+++ b/src/memory/builtin/library.cpp
@@ -24,7 +24,7 @@ Library::~Library() {
 
 LibraryClass::LibraryClass() : Class("lib", Class::library) {
 
-	createBuiltinMember("new", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("new", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -42,7 +42,7 @@ LibraryClass::LibraryClass() : Class("lib", Class::library) {
 							}
 						}));
 
-	createBuiltinMember("call", -2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("call", -2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 

--- a/src/memory/builtin/string.cpp
+++ b/src/memory/builtin/string.cpp
@@ -28,7 +28,7 @@ enum Flag {
 	string_sign = 0x40
 };
 
-void string_format(AbstractSynatxTree *ast, string &dest, const string &format, const Array::values_type &args);
+void string_format(AbstractSyntaxTree *ast, string &dest, const string &format, const Array::values_type &args);
 template<typename numtype>
 string string_integer(numtype number, int base, int size, int precision, int flags);
 template<typename numtype>
@@ -38,7 +38,7 @@ string string_hex_real(numtype number, int size, int precision, int flags);
 
 StringClass::StringClass() : Class("string", Class::string) {
 
-	createBuiltinMember(":=", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember(":=", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -50,7 +50,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 							ast->stack().pop_back();
 						}));
 
-	createBuiltinMember("+", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("+", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -66,7 +66,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember("%", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("%", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -82,7 +82,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember("==", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("==", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -97,7 +97,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember("!=", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("!=", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -112,7 +112,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember("<", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("<", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -127,7 +127,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember(">", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember(">", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -143,7 +143,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 
 						}));
 
-	createBuiltinMember("<=", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("<=", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -158,7 +158,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember(">=", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember(">=", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -173,7 +173,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember("&&", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("&&", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -188,7 +188,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember("||", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("||", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -203,7 +203,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember("^", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("^", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -218,7 +218,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember("!", 1, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("!", 1, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							Reference &value = *ast->stack().back();
 
@@ -229,7 +229,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember("[]", 2, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("[]", 2, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -247,7 +247,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 
 	/// \todo register operator overloads
 
-	createBuiltinMember("size", 1, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("size", 1, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							Reference &value = *ast->stack().back();
 
@@ -258,7 +258,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember("empty", 1, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("empty", 1, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							Reference &value = *ast->stack().back();
 
@@ -269,7 +269,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 							ast->stack().push_back(SharedReference::unique(result));
 						}));
 
-	createBuiltinMember("clear", 1, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("clear", 1, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							SharedReference value = ast->stack().back();
 
@@ -279,7 +279,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 							ast->stack().push_back(value);
 						}));
 
-	createBuiltinMember("replace", 3, AbstractSynatxTree::createBuiltinMethode(metatype(), [] (AbstractSynatxTree *ast) {
+	createBuiltinMember("replace", 3, AbstractSyntaxTree::createBuiltinMethode(metatype(), [] (AbstractSyntaxTree *ast) {
 
 							size_t base = get_base(ast);
 
@@ -301,7 +301,7 @@ StringClass::StringClass() : Class("string", Class::string) {
 						}));
 }
 
-void string_format(AbstractSynatxTree *ast, string &dest, const string &format, const Array::values_type &args) {
+void string_format(AbstractSyntaxTree *ast, string &dest, const string &format, const Array::values_type &args) {
 
 	int flags = 0;
 

--- a/src/memory/casttool.cpp
+++ b/src/memory/casttool.cpp
@@ -21,7 +21,7 @@ string number_to_char(long number) {
 	return result;
 }
 
-double to_number(AbstractSynatxTree *ast, const Reference &ref) {
+double to_number(AbstractSyntaxTree *ast, const Reference &ref) {
 
 	switch (ref.data()->format) {
 	case Data::fmt_none:
@@ -79,7 +79,7 @@ double to_number(AbstractSynatxTree *ast, const Reference &ref) {
 	return 0;
 }
 
-bool to_boolean(AbstractSynatxTree *ast, const Reference &ref) {
+bool to_boolean(AbstractSyntaxTree *ast, const Reference &ref) {
 
 	((void)ast);
 

--- a/src/memory/memorytool.cpp
+++ b/src/memory/memorytool.cpp
@@ -8,7 +8,7 @@
 
 using namespace std;
 
-size_t get_base(AbstractSynatxTree *ast) {
+size_t get_base(AbstractSyntaxTree *ast) {
 	return ast->stack().size() - 1;
 }
 
@@ -87,7 +87,7 @@ void print(Printer *printer, SharedReference ref) {
 	}
 }
 
-void init_call(AbstractSynatxTree *ast) {
+void init_call(AbstractSyntaxTree *ast) {
 
 	if (ast->stack().back()->data()->format == Data::fmt_object) {
 
@@ -133,7 +133,7 @@ void init_call(AbstractSynatxTree *ast) {
 	}
 }
 
-void exit_call(AbstractSynatxTree *ast) {
+void exit_call(AbstractSyntaxTree *ast) {
 
 	if (!ast->stack().back().isUnique()) {
 		Reference &lvalue = *ast->stack().back();
@@ -145,7 +145,7 @@ void exit_call(AbstractSynatxTree *ast) {
 	ast->exitCall();
 }
 
-void init_parameter(AbstractSynatxTree *ast, const std::string &symbol) {
+void init_parameter(AbstractSyntaxTree *ast, const std::string &symbol) {
 
 	SharedReference value = ast->stack().back();
 	ast->stack().pop_back();
@@ -158,7 +158,7 @@ void init_parameter(AbstractSynatxTree *ast, const std::string &symbol) {
 	}
 }
 
-Function::mapping_type::iterator find_function_signature(AbstractSynatxTree *ast, Function::mapping_type &mapping, int signature) {
+Function::mapping_type::iterator find_function_signature(AbstractSyntaxTree *ast, Function::mapping_type &mapping, int signature) {
 
 	auto it = mapping.find(signature);
 
@@ -188,7 +188,7 @@ Function::mapping_type::iterator find_function_signature(AbstractSynatxTree *ast
 	return it;
 }
 
-void yield(AbstractSynatxTree *ast) {
+void yield(AbstractSyntaxTree *ast) {
 
 	Reference &default_result = ast->symbols().defaultResult;
 	if (default_result.data()->format == Data::fmt_none) {
@@ -199,7 +199,7 @@ void yield(AbstractSynatxTree *ast) {
 	ast->stack().pop_back();
 }
 
-void load_default_result(AbstractSynatxTree *ast) {
+void load_default_result(AbstractSyntaxTree *ast) {
 	ast->stack().push_back(SharedReference::unique(new Reference(ast->symbols().defaultResult)));
 }
 
@@ -217,7 +217,7 @@ SharedReference get_symbol_reference(SymbolTable *symbols, const std::string &sy
 	return &(*symbols)[symbol];
 }
 
-SharedReference get_object_member(AbstractSynatxTree *ast, const std::string &member) {
+SharedReference get_object_member(AbstractSyntaxTree *ast, const std::string &member) {
 
 	Reference *result = nullptr;
 	Reference &lvalue = *ast->stack().back();
@@ -297,7 +297,7 @@ SharedReference get_object_member(AbstractSynatxTree *ast, const std::string &me
 	return result;
 }
 
-void reduce_member(AbstractSynatxTree *ast) {
+void reduce_member(AbstractSyntaxTree *ast) {
 
 	SharedReference member = ast->stack().back();
 	ast->stack().pop_back();
@@ -305,7 +305,7 @@ void reduce_member(AbstractSynatxTree *ast) {
 	ast->stack().push_back(member);
 }
 
-string var_symbol(AbstractSynatxTree *ast) {
+string var_symbol(AbstractSyntaxTree *ast) {
 
 	Reference var = *ast->stack().back();
 	ast->stack().pop_back();
@@ -313,7 +313,7 @@ string var_symbol(AbstractSynatxTree *ast) {
 	return to_string(var);
 }
 
-void create_symbol(AbstractSynatxTree *ast, const std::string &symbol, Reference::Flags flags) {
+void create_symbol(AbstractSyntaxTree *ast, const std::string &symbol, Reference::Flags flags) {
 
 	if (flags & Reference::global) {
 
@@ -341,7 +341,7 @@ void create_symbol(AbstractSynatxTree *ast, const std::string &symbol, Reference
 	}
 }
 
-void array_append(AbstractSynatxTree *ast) {
+void array_append(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -377,7 +377,7 @@ size_t array_index(Array *array, long index) {
 	return i;
 }
 
-void hash_insert(AbstractSynatxTree *ast) {
+void hash_insert(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -420,7 +420,7 @@ SharedReference hash_get_value(const Hash::values_type::value_type &item) {
 	return item.second.get();
 }
 
-void iterator_init(AbstractSynatxTree *ast, size_t length) {
+void iterator_init(AbstractSyntaxTree *ast, size_t length) {
 
 	Reference *it = new Reference(Reference::const_ref, Reference::alloc<Iterator>());
 	((Object *)it->data())->construct();
@@ -487,12 +487,12 @@ bool iterator_next(Iterator *iterator, SharedReference &item) {
 	return true;
 }
 
-void regex_match(AbstractSynatxTree *ast) {
+void regex_match(AbstractSyntaxTree *ast) {
 	((void)ast);
 	error("regex are not supported in this version");
 }
 
-void regex_unmatch(AbstractSynatxTree *ast) {
+void regex_unmatch(AbstractSyntaxTree *ast) {
 	((void)ast);
 	error("regex are not supported in this version");
 }

--- a/src/memory/object.cpp
+++ b/src/memory/object.cpp
@@ -28,12 +28,12 @@ Object::~Object() {
 		auto destructor = metadata->members().find("delete");
 		if (destructor != metadata->members().end()) {
 
-			AbstractSynatxTree ast;
+			AbstractSyntaxTree ast;
 
 			ast.stack().push_back(SharedReference::unique(new Reference(Reference::standard, this)));
 			ast.waitingCalls().push(&data[destructor->second->offset]);
 
-			AbstractSynatxTree::CallHandler handler = ast.getCallHandler();
+			AbstractSyntaxTree::CallHandler handler = ast.getCallHandler();
 			call_member_operator(&ast, 0);
 			while (ast.callInProgress(handler)) {
 				run_step(&ast);

--- a/src/memory/operatortool.cpp
+++ b/src/memory/operatortool.cpp
@@ -10,7 +10,7 @@
 
 using namespace std;
 
-bool call_overload(AbstractSynatxTree *ast, const string &operator_overload, int signature) {
+bool call_overload(AbstractSyntaxTree *ast, const string &operator_overload, int signature) {
 
 	size_t base = get_base(ast);
 	Object *object = (Object *)ast->stack().at(base - signature)->data();
@@ -25,7 +25,7 @@ bool call_overload(AbstractSynatxTree *ast, const string &operator_overload, int
 	return true;
 }
 
-void move_operator(AbstractSynatxTree *ast) {
+void move_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -45,7 +45,7 @@ void move_operator(AbstractSynatxTree *ast) {
 	ast->stack().pop_back();
 }
 
-void copy_operator(AbstractSynatxTree *ast) {
+void copy_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -93,7 +93,7 @@ void copy_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void call_operator(AbstractSynatxTree *ast, int signature) {
+void call_operator(AbstractSyntaxTree *ast, int signature) {
 
 	Reference *result = nullptr;
 	Reference lvalue = ast->waitingCalls().top().function();
@@ -143,7 +143,7 @@ void call_operator(AbstractSynatxTree *ast, int signature) {
 	}
 }
 
-void call_member_operator(AbstractSynatxTree *ast, int signature) {
+void call_member_operator(AbstractSyntaxTree *ast, int signature) {
 
 	size_t base = get_base(ast);
 
@@ -201,7 +201,7 @@ void call_member_operator(AbstractSynatxTree *ast, int signature) {
 	}
 }
 
-void add_operator(AbstractSynatxTree *ast) {
+void add_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -253,7 +253,7 @@ void add_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void sub_operator(AbstractSynatxTree *ast) {
+void sub_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -293,7 +293,7 @@ void sub_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void mul_operator(AbstractSynatxTree *ast) {
+void mul_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -332,7 +332,7 @@ void mul_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void div_operator(AbstractSynatxTree *ast) {
+void div_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -372,7 +372,7 @@ void div_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void pow_operator(AbstractSynatxTree *ast) {
+void pow_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -406,7 +406,7 @@ void pow_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void mod_operator(AbstractSynatxTree *ast) {
+void mod_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -440,7 +440,7 @@ void mod_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void is_operator(AbstractSynatxTree *ast) {
+void is_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -454,7 +454,7 @@ void is_operator(AbstractSynatxTree *ast) {
 	ast->stack().push_back(SharedReference::unique(result));
 }
 
-void eq_operator(AbstractSynatxTree *ast) {
+void eq_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -527,7 +527,7 @@ void eq_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void ne_operator(AbstractSynatxTree *ast) {
+void ne_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -600,7 +600,7 @@ void ne_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void lt_operator(AbstractSynatxTree *ast) {
+void lt_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -640,7 +640,7 @@ void lt_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void gt_operator(AbstractSynatxTree *ast) {
+void gt_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -680,7 +680,7 @@ void gt_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void le_operator(AbstractSynatxTree *ast) {
+void le_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -720,7 +720,7 @@ void le_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void ge_operator(AbstractSynatxTree *ast) {
+void ge_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -760,7 +760,7 @@ void ge_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void and_operator(AbstractSynatxTree *ast) {
+void and_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -800,7 +800,7 @@ void and_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void or_operator(AbstractSynatxTree *ast) {
+void or_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -840,7 +840,7 @@ void or_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void band_operator(AbstractSynatxTree *ast) {
+void band_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -880,7 +880,7 @@ void band_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void bor_operator(AbstractSynatxTree *ast) {
+void bor_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -920,7 +920,7 @@ void bor_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void xor_operator(AbstractSynatxTree *ast) {
+void xor_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -960,7 +960,7 @@ void xor_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void inc_operator(AbstractSynatxTree *ast) {
+void inc_operator(AbstractSyntaxTree *ast) {
 
 	Reference &value = *ast->stack().back();
 	Reference *result;
@@ -993,7 +993,7 @@ void inc_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void dec_operator(AbstractSynatxTree *ast) {
+void dec_operator(AbstractSyntaxTree *ast) {
 
 	Reference &value = *ast->stack().back();
 	Reference *result;
@@ -1026,7 +1026,7 @@ void dec_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void not_operator(AbstractSynatxTree *ast) {
+void not_operator(AbstractSyntaxTree *ast) {
 
 	Reference &value = *ast->stack().back();
 	Reference *result = Reference::create<Boolean>();
@@ -1059,7 +1059,7 @@ void not_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void compl_operator(AbstractSynatxTree *ast) {
+void compl_operator(AbstractSyntaxTree *ast) {
 
 	Reference &value = *ast->stack().back();
 	Reference *result;
@@ -1094,7 +1094,7 @@ void compl_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void pos_operator(AbstractSynatxTree *ast) {
+void pos_operator(AbstractSyntaxTree *ast) {
 
 	Reference &value = *ast->stack().back();
 	Reference *result;
@@ -1129,7 +1129,7 @@ void pos_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void neg_operator(AbstractSynatxTree *ast) {
+void neg_operator(AbstractSyntaxTree *ast) {
 
 	Reference &value = *ast->stack().back();
 	Reference *result;
@@ -1164,7 +1164,7 @@ void neg_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void shift_left_operator(AbstractSynatxTree *ast) {
+void shift_left_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -1204,7 +1204,7 @@ void shift_left_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void shift_right_operator(AbstractSynatxTree *ast) {
+void shift_right_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -1244,7 +1244,7 @@ void shift_right_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void inclusive_range_operator(AbstractSynatxTree *ast) {
+void inclusive_range_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -1287,7 +1287,7 @@ void inclusive_range_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void exclusive_range_operator(AbstractSynatxTree *ast) {
+void exclusive_range_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -1331,7 +1331,7 @@ void exclusive_range_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void typeof_operator(AbstractSynatxTree *ast) {
+void typeof_operator(AbstractSyntaxTree *ast) {
 
 	Reference &value = *ast->stack().back();
 	Reference *result = Reference::create<String>();
@@ -1342,7 +1342,7 @@ void typeof_operator(AbstractSynatxTree *ast) {
 	ast->stack().push_back(SharedReference::unique(result));
 }
 
-void membersof_operator(AbstractSynatxTree *ast) {
+void membersof_operator(AbstractSyntaxTree *ast) {
 
 	Reference &value = *ast->stack().back();
 	Reference *result = Reference::create<Array>();
@@ -1375,7 +1375,7 @@ void membersof_operator(AbstractSynatxTree *ast) {
 	ast->stack().push_back(SharedReference::unique(result));
 }
 
-void subscript_operator(AbstractSynatxTree *ast) {
+void subscript_operator(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -1421,7 +1421,7 @@ void subscript_operator(AbstractSynatxTree *ast) {
 	}
 }
 
-void iterator_move(Iterator *iterator, Reference *dest, AbstractSynatxTree *ast) {
+void iterator_move(Iterator *iterator, Reference *dest, AbstractSyntaxTree *ast) {
 
 	if (!iterator->ctx.empty()) {
 		ast->stack().push_back(dest);
@@ -1431,7 +1431,7 @@ void iterator_move(Iterator *iterator, Reference *dest, AbstractSynatxTree *ast)
 	}
 }
 
-void find_defined_symbol(AbstractSynatxTree *ast, const std::string &symbol) {
+void find_defined_symbol(AbstractSyntaxTree *ast, const std::string &symbol) {
 
 	if (Class *desc = GlobalData::instance().getClass(symbol)) {
 		Object *object = desc->makeInstance();
@@ -1458,7 +1458,7 @@ void find_defined_symbol(AbstractSynatxTree *ast, const std::string &symbol) {
 
 }
 
-void find_defined_member(AbstractSynatxTree *ast, const std::string &symbol) {
+void find_defined_member(AbstractSyntaxTree *ast, const std::string &symbol) {
 
 	if (ast->stack().back()->data()->format != Data::fmt_none) {
 
@@ -1498,7 +1498,7 @@ void find_defined_member(AbstractSynatxTree *ast, const std::string &symbol) {
 	}
 }
 
-void check_defined(AbstractSynatxTree *ast) {
+void check_defined(AbstractSyntaxTree *ast) {
 
 	SharedReference value = ast->stack().back();
 	Reference *result = Reference::create<Boolean>();
@@ -1509,7 +1509,7 @@ void check_defined(AbstractSynatxTree *ast) {
 	ast->stack().push_back(SharedReference::unique(result));
 }
 
-void in_find(AbstractSynatxTree *ast) {
+void in_find(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -1545,7 +1545,7 @@ void in_find(AbstractSynatxTree *ast) {
 	ast->stack().push_back(SharedReference::unique(result));
 }
 
-void in_init(AbstractSynatxTree *ast) {
+void in_init(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -1559,7 +1559,7 @@ void in_init(AbstractSynatxTree *ast) {
 	iterator_move(iterator, &lvalue, ast);
 }
 
-void in_next(AbstractSynatxTree *ast) {
+void in_next(AbstractSyntaxTree *ast) {
 
 	size_t base = get_base(ast);
 
@@ -1571,7 +1571,7 @@ void in_next(AbstractSynatxTree *ast) {
 	iterator_move(iterator, &lvalue, ast);
 }
 
-void in_check(AbstractSynatxTree *ast) {
+void in_check(AbstractSyntaxTree *ast) {
 
 	Reference &rvalue = *ast->stack().back();
 	Reference *result = Reference::create<Boolean>();
@@ -1593,12 +1593,12 @@ void in_check(AbstractSynatxTree *ast) {
 
 bool Hash::compare::operator ()(const SharedReference &a, const SharedReference &b) const {
 
-	AbstractSynatxTree ast;
+	AbstractSyntaxTree ast;
 
 	ast.stack().push_back(SharedReference::unique(new Reference(*a)));
 	ast.stack().push_back(SharedReference::unique(new Reference(*b)));
 
-	AbstractSynatxTree::CallHandler handler = ast.getCallHandler();
+	AbstractSyntaxTree::CallHandler handler = ast.getCallHandler();
 	lt_operator(&ast);
 	while (ast.callInProgress(handler)) {
 		run_step(&ast);

--- a/src/scheduler/processor.cpp
+++ b/src/scheduler/processor.cpp
@@ -6,7 +6,7 @@
 #include "memory/operatortool.h"
 #include "memory/globaldata.h"
 
-bool run_step(AbstractSynatxTree *ast) {
+bool run_step(AbstractSyntaxTree *ast) {
 
 	switch (ast->next().command) {
 	case Instruction::load_module:

--- a/src/system/plugin.cpp
+++ b/src/system/plugin.cpp
@@ -48,7 +48,7 @@ string Plugin::functionName(const string &name, int signature) {
 	return name + "_" + to_string(signature);
 }
 
-bool Plugin::call(const string &function, int signature, AbstractSynatxTree *ast) {
+bool Plugin::call(const string &function, int signature, AbstractSyntaxTree *ast) {
 
 	if (function_type fcn_handle = getFunction(functionName(function, signature))) {
 		fcn_handle(ast);


### PR DESCRIPTION
“Synatx” doesn’t mean anything and was clearly a typo.